### PR TITLE
Update regex to avoid /e depreciation

### DIFF
--- a/src/MiladRahimi/PHPRouter/Router.php
+++ b/src/MiladRahimi/PHPRouter/Router.php
@@ -260,7 +260,9 @@ class Router {
      * @return string Pattern
      */
     private function convertToRegex($route) {
-        return '@^' . preg_replace("@{([^}]+)}@", '$this->regexParameter("$1")', $route) . '$@';
+        return '@^' . preg_replace_callback("@{([^}]+)}@", function ($match) {
+            return $this->regexParameter($match[0]);
+        }, $route) . '$@';
     }
 
     /**

--- a/src/MiladRahimi/PHPRouter/Router.php
+++ b/src/MiladRahimi/PHPRouter/Router.php
@@ -260,7 +260,7 @@ class Router {
      * @return string Pattern
      */
     private function convertToRegex($route) {
-        return '@^' . preg_replace("@{([^}]+)}@e", '$this->regexParameter("$1")', $route) . '$@';
+        return '@^' . preg_replace("@{([^}]+)}@", '$this->regexParameter("$1")', $route) . '$@';
     }
 
     /**


### PR DESCRIPTION
Update the regex line to avoid the notice message:

_The /e modifier is deprecated, use preg_replace_callback_

php version: 5.6.13
