### PR TITLE
Fix middleware call

### DIFF
--- a/src/MiladRahimi/PHPRouter/Router.php
+++ b/src/MiladRahimi/PHPRouter/Router.php
@@ -218,7 +218,9 @@ class Router {
                                 if (method_exists($list[0], $list[1])) {
                                     $mid_args = $arguments;
                                     $mid_args = $this->arrangeMethodArgs($list[0], $list[1], $mid_args);
-                                    $this->publish(call_user_func_array($list[0]->$list[1], $mid_args));
+
+                                    $mid_instance = new $list[0];
+                                    $this->publish(call_user_func_array(array($mid_instance, $list[1]), $mid_args));
                                 } else {
                                     throw new BadMiddleware('Cannot detect the middleware method');
                                 }


### PR DESCRIPTION
I was having trouble to use middleware

```
$router->post("/register/save", "Controller\RegisterController@save", "Middleware\RegisterMiddleware@validate");
```

I was getting this errors:

> Notice: Trying to get property of non-object ... Router.php on line 221
> Warning: call_user_func_array() expects parameter 1 to be a valid callback, no array or string given ... Router.php on line 221

So I use the example 1 from [php.net](http://php.net/manual/en/function.call-user-func-array.php)

I am using PHP version: 5.5.12
