### PR TITLE
Bugfix: Urlencoded query strings would cause the router to miss defined routes

### DIFF
--- a/src/MiladRahimi/PHPRouter/Request.php
+++ b/src/MiladRahimi/PHPRouter/Request.php
@@ -127,7 +127,8 @@ class Request
     private function __construct(Router $router)
     {
         $this->router = $router;
-        $u = $this->uri = urldecode($_SERVER["REQUEST_URI"]);
+        $u = $_SERVER["REQUEST_URI"];
+        $this->uri = urldecode($u);
         $q = $this->query_string = $_SERVER["QUERY_STRING"];
         $this->page = trim(substr($u, 0, strlen($u) - strlen($q)), '?');
         $this->method = $_SERVER["REQUEST_METHOD"];


### PR DESCRIPTION
When you try to access a URL with a urlencoded query string, the router would fail to route the request to the correct method. This was due to a greedy chop off.

## Example
`/test?t=%2B4712345678` becomes `/test/t=+4712345678`. Then the latter is chopped off by the length of `t=%2B4712345678`. This results in a path that's too short and would fail to route. Resulting in a `HTTP 404`.