### PR TITLE
Check if $_SERVER['QUERY_STRING'] exists before using it

### DIFF
--- a/src/MiladRahimi/PHPRouter/Request.php
+++ b/src/MiladRahimi/PHPRouter/Request.php
@@ -129,7 +129,7 @@ class Request
         $this->router = $router;
         $u = $_SERVER["REQUEST_URI"];
         $this->uri = $u ? urldecode($u) : null;
-        $q = $this->query_string = $_SERVER["QUERY_STRING"] ?: null;
+        $q = $this->query_string = empty($_SERVER["QUERY_STRING"]) ? null : $_SERVER["QUERY_STRING"];
         $this->page = trim(substr($u, 0, strlen($u) - strlen($q)), '?');
         $this->method = $_SERVER["REQUEST_METHOD"];
         $this->protocol = $_SERVER["SERVER_PROTOCOL"];


### PR DESCRIPTION
This prevents an error when $_SERVER['QUERY_STRING'] doesn't exist (generally when using a non-Apache server as the PHP's buit in server).
Fixes #4 .